### PR TITLE
Configurable conversion amount in Wrath Forge

### DIFF
--- a/src/main/java/factorization/common/Core.java
+++ b/src/main/java/factorization/common/Core.java
@@ -100,6 +100,7 @@ public class Core {
     public static boolean enable_sketchy_client_commands = true;
     public static int max_rocket_base_size = 20*20;
     public static int max_rocket_height = 64;
+    public static int wrath_forge_conversions = 36;
 
     // universal constant config
     public final static String texture_dir = "/factorization/texture/";
@@ -210,6 +211,7 @@ public class Core {
         serverside_translate = getBoolConfig("serversideTranslate", "server", serverside_translate, "If false, notifications will be translated by the client");
         boilers_suck_water = getBoolConfig("boilersSuckWater", "server", boilers_suck_water, "If false, water must be piped in");
         steam_output_adjust = getDoubleConfig("steamOutputAdjustment", "server", steam_output_adjust, "Scale how much steam is produced by the solar boiler");
+        wrath_forge_conversions = getIntConfig("wrathForgeConversions", "server", wrath_forge_conversions, "Amount of conversions with one fire inside the wrath forge (Set to -1 for infinite).");
 
         config.save();
     }

--- a/src/main/java/factorization/common/TileEntityWrathFire.java
+++ b/src/main/java/factorization/common/TileEntityWrathFire.java
@@ -159,6 +159,7 @@ public class TileEntityWrathFire extends TileEntity implements ICoord {
 
     BlockMatch host = null;
     int age = 0, generation = 0;
+    int wrathConversions = 0;
 
     int random_time_offset = rand.nextInt();
 
@@ -171,6 +172,7 @@ public class TileEntityWrathFire extends TileEntity implements ICoord {
         tag.setInteger("host_id", host.id);
         tag.setInteger("host_md", host.md);
         tag.setInteger("age", age);
+        tag.setInteger("wrathConversions", wrathConversions);
         tag.setInteger("generation", generation);
     }
 
@@ -179,6 +181,7 @@ public class TileEntityWrathFire extends TileEntity implements ICoord {
         super.readFromNBT(tag);
         host = new BlockMatch(tag.getInteger("host_id"), tag.getInteger("host_md"));
         age = tag.getInteger("age");
+        wrathConversions = tag.getInteger("wrathConversions");
         generation = tag.getInteger("generation");
     }
 
@@ -276,7 +279,7 @@ public class TileEntityWrathFire extends TileEntity implements ICoord {
         if (rand.nextFloat() > .95) {
             return;
         }
-        if (age > max_age) {
+        if (age > max_age || (Core.wrath_forge_conversions > -1 && wrathConversions >= Core.wrath_forge_conversions)) {
             die();
             return;
         }
@@ -325,7 +328,7 @@ public class TileEntityWrathFire extends TileEntity implements ICoord {
                             continue; //don't burn something that we're just going to reverse
                         }
                         burnsTo.set(c);
-                        age++;
+                        wrathConversions++;
                         return;
                     }
                 }


### PR DESCRIPTION
Adds a config option to specify the amount of maximum conversions inside the Wrath Forge.

I always felt like the Wrath Forge is pretty underwhelming, as you could just place down a big area of Iron Blocks and convert more that way cheaper. The Wrath Forge is a slower automatable alternative. Increasing the conversions per fire gives the player more incentive to actually build it.

The default config option is 36, as per Factorization default. This allows pack creators to change that behaviour, either by increasing the amount of conversions or allow infinite conversion by setting it to -1. I wouldn't mind changing the default, but that's up to you (and neptunepink) to decide.

This feature was originally part of [UpsilonFixes](https://git.sleeping.town/Rewind/UpsilonFixes/pulls/4/files), but I expanded it since I can actually write Java Code and don't have to ASM everything in.